### PR TITLE
fix: handle drawing outside of declared surface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 use embedded_graphics::{
     draw_target::DrawTarget,
     geometry::OriginDimensions,
-    prelude::{PixelColor, Size},
+    prelude::{PixelColor, Size, Point},
     Pixel,
 };
-use std::convert::TryInto;
 
 #[repr(transparent)]
 #[derive(Copy, Clone)]
@@ -68,8 +67,8 @@ impl<C: PixelColor, const X: usize, const Y: usize> DrawTarget for FrameBuf<C, X
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
         for Pixel(coord, color) in pixels.into_iter() {
-            if let Ok(pos) = coord.try_into() {
-                let (x, y): (u32, u32) = pos;
+            if coord.x >= 0 && coord.x < X as i32 && coord.y >= 0 && coord.y < Y as i32 {
+                let Point { x, y } = coord;
                 self.0[y as usize][x as usize] = color;
             }
         }


### PR DESCRIPTION
Fix #2 

This PR adds a boundary check and ignore pixels drawn outside of the declared surface.