### PR TITLE
Updated examples for improved performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Make sure you have your `rust` environment configurated
         .draw(&mut fbuf)
         .unwrap();
     // Write it all to the display
-    display.draw_iter(fbuf.into_iter()).unwrap();
+    let area = Rectangle::new(Point::new(0, 0), fbuf.size());
+    display.fill_contiguous(&area, data).unwrap();
     ```
 3. Your flickering problems should be solved at this point :)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!     mock_display::MockDisplay,
 //!     pixelcolor::BinaryColor,
 //!     prelude::{Point, Primitive},
-//!     primitives::{Line, PrimitiveStyle},
+//!     primitives::{Line, PrimitiveStyle, Rectangle},
 //!     Drawable,
 //! };
 //! use embedded_graphics_framebuf::FrameBuf;
@@ -126,6 +126,11 @@ impl<C: PixelColor, B: FrameBufferBackend<Color = C>> FrameBuf<C, B> {
         self.height
     }
 
+    /// Get the framebuffers size.
+    pub fn size(&self) -> Size {
+        Size::new(self.width as u32, self.height as u32)
+    }
+
     fn point_to_index(&self, p: Point) -> usize {
         self.width * p.y as usize + p.x as usize
     }
@@ -183,7 +188,7 @@ impl<'a, C: PixelColor, B: FrameBufferBackend<Color = C>> IntoIterator for &'a F
 
 impl<C: PixelColor, B: FrameBufferBackend<Color = C>> OriginDimensions for FrameBuf<C, B> {
     fn size(&self) -> Size {
-        Size::new(self.width as u32, self.height as u32)
+        self.size()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
 //!     .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
 //!     .draw(&mut fbuf)
 //!     .unwrap();
-//! display.draw_iter(fbuf.into_iter()).unwrap();
+//! let area = Rectangle::new(Point::new(0, 0), fbuf.size());
+//! display.fill_contiguous(&area, data).unwrap();
 //! ```
 
 #![no_std]


### PR DESCRIPTION
Changed the examples to use .fill_contiguous() instead of .draw_iter() as it has better performance on many displays. If the .fill_contiguous() method is not implemented by the display driver it will fall back to .draw_iter(). 