### PR TITLE
Feature/embedded graphics 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-graphics-framebuf"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
   "Bernard Kobos <bkobos@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ description = "Frame buffer helper for embedded-graphics"
 
 [dependencies]
 embedded-dma = "0.2.0"
-embedded-graphics = "0.7"
+embedded-graphics = "0.8.0"


### PR DESCRIPTION
There is a new release of Embedded Graphics 0.8.

PR is updating dependency from 0.7 to 0.8.

API seems to be without breaking changes.