### PR TITLE
Add impl for embedded_dma::WriteBuffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! ```
 
 #![no_std]
-use embedded_dma::ReadBuffer;
+use embedded_dma::{ReadBuffer, WriteBuffer};
 use embedded_graphics::{
     draw_target::DrawTarget,
     geometry::OriginDimensions,
@@ -274,6 +274,20 @@ unsafe impl<C: PixelColor, B: DMACapableFrameBufferBackend<Color = C>> ReadBuffe
     unsafe fn read_buffer(&self) -> (*const Self::Word, usize) {
         (
             (self.data.data_ptr() as *const Self::Word),
+            self.height
+                * self.width
+                * (core::mem::size_of::<C>() / core::mem::size_of::<Self::Word>()),
+        )
+    }
+}
+
+unsafe impl<C: PixelColor, B: DMACapableFrameBufferBackend<Color = C>> WriteBuffer
+    for FrameBuf<C, B>
+{
+    type Word = u8;
+    unsafe fn write_buffer(&mut self) -> (*mut Self::Word, usize) {
+        (
+            (self.data.data_ptr() as *mut Self::Word),
             self.height
                 * self.width
                 * (core::mem::size_of::<C>() / core::mem::size_of::<Self::Word>()),


### PR DESCRIPTION
Allows the Framebuf to be used as a DMA WriteTarget.
**Why would you want this?**
Using DMA makes certain operations much faster.  On an rp2040 clearing a `[Rgb565; 240*240]` buffer via 
software takes 2.6ms, but DMA can zero it in 103us.
Copying a buffer while swapping the word order takes 260us with DMA, meaning I don't need the overhead that comes with EndianCorrectedBuffer.  I don't have a hard number for this one, as it's very implementation specific, but in my use case I've seen a marked improvement in performance.
There are probably further uses too, such as sprite copying.

Previously only a ReadTarget impl existed